### PR TITLE
Encryption of Payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
+        "@types/crypto-js": "^4.2.2",
         "astro": ">=4.0.0",
+        "crypto-js": "^4.2.0",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -1467,6 +1469,11 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2200,6 +2207,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@types/crypto-js": "^4.2.2",
         "astro": ">=4.0.0",
         "crypto-js": "^4.2.0",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.2.2",
         "@types/node": "^22.0.0",
         "vitest": "^2.0.0"
       }
@@ -1472,7 +1472,8 @@
     "node_modules/@types/crypto-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
-      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "author": "koyopro",
   "license": "MIT",
   "dependencies": {
+    "@types/crypto-js": "^4.2.2",
     "astro": ">=4.0.0",
+    "crypto-js": "^4.2.0",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   "author": "koyopro",
   "license": "MIT",
   "dependencies": {
-    "@types/crypto-js": "^4.2.2",
     "astro": ">=4.0.0",
     "crypto-js": "^4.2.0",
     "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^22.0.0",
     "vitest": "^2.0.0"
   }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -71,6 +71,9 @@ export class CookieStorage {
   }
 
   save() {
+    // Create a JWT with a payload encrypted using AES-CBC
+    // - PASETO or JWE (AES-GCM) libraries with synchronous APIs were not found
+    // - AES-CBC alone does not provide tamper resistance, but it is protected by the JWT signature
     const encryptedData = CryptoJS.AES.encrypt(
       JSON.stringify(this.data),
       this.secret

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -3,6 +3,7 @@ import pkg from "jsonwebtoken";
 const { sign, verify, JsonWebTokenError } = pkg;
 
 import type { AstroCookies, AstroCookieSetOptions } from "astro";
+import CryptoJS from "crypto-js";
 import type { Options } from "./index.js";
 import { getSecret } from "./secret.js";
 
@@ -52,20 +53,29 @@ export class CookieStorage {
   restore(jwt: string | undefined) {
     if (!jwt) return;
     try {
-      const v = verify(jwt, this.secret, { algorithms: ["HS256"] });
-      if (!v || typeof v !== "object") return;
-      Object.assign(this.data as any, v);
-    } catch (e: unknown) {
-      if (e instanceof JsonWebTokenError) {
-        // ignore
-      } else {
-        throw e;
+      let payload = verify(jwt, this.secret, { algorithms: ["HS256"] });
+      if (!payload) return;
+      if (typeof payload === "string") {
+        const encryptedData = CryptoJS.AES.decrypt(payload, this.secret);
+        const jsonData = encryptedData.toString(CryptoJS.enc.Utf8);
+        payload = JSON.parse(jsonData);
       }
+      Object.assign(this.data as any, payload);
+    } catch (e: unknown) {
+      if (e instanceof JsonWebTokenError || e instanceof SyntaxError) {
+        // Ignore invalid JWT or JSON parse errors
+        return;
+      }
+      throw e;
     }
   }
 
   save() {
-    const jwt = sign(this.data, this.secret, { algorithm: "HS256" });
+    const encryptedData = CryptoJS.AES.encrypt(
+      JSON.stringify(this.data),
+      this.secret
+    ).toString();
+    const jwt = sign(encryptedData, this.secret, { algorithm: "HS256" });
     this.cookies.set(this.key, jwt, this.setOptions);
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -77,6 +77,17 @@ test("secure", () => {
   expect(data["astro.session"]).not.toContain("myValue");
 });
 
+test("JWT verification", () => {
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXlGb3JTdHJpbmciOiJteVZhbHVlIiwiaWF0IjoxNzQ0OTk5ODE5fQ.ZbBheRT6Z6JDuFM0qmwm25N_07i9ziqzWe6Bahwye8k";
+  data["astro.session"] = jwt;
+
+  const { getSession } = createCookieSessionStorage<SessionData>();
+  const session = getSession(mockAstroCookies);
+
+  expect(session.get("keyForString")).toBe("myValue");
+});
+
 test("cookieName option", () => {
   const { getSession } = createCookieSessionStorage<SessionData>({
     cookieName: "myCookieName",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -75,6 +75,11 @@ test("secure", () => {
 
   expect(data["astro.session"]).not.toContain("keyForString");
   expect(data["astro.session"]).not.toContain("myValue");
+
+  // Verify that the value is encrypted
+  const encodedValue: string = data["astro.session"]?.split(".")[1] || "";
+  const value = Buffer.from(encodedValue, "base64").toString("utf-8");
+  expect(() => JSON.parse(value)).toThrow(SyntaxError);
 });
 
 test("JWT verification", () => {


### PR DESCRIPTION
This pull request introduces encryption for the payload of JSON Web Tokens (JWTs) using AES-CBC, enhances error handling, and updates dependencies to support the new functionality. The most important changes include adding the `crypto-js` library, modifying the `CookieStorage` class to encrypt and decrypt JWT payloads, and adding tests to validate the encryption and decryption process.

This closes #3 

### Encryption and Decryption of JWT Payloads:
* Updated the `restore` method in the `CookieStorage` class to decrypt JWT payloads using AES-CBC when the payload is a string. Added logic to handle JSON parsing errors gracefully. (`src/storage.ts`, [src/storage.tsL55-R81](diffhunk://#diff-10d5d48c419530b01c345d22a42140d1a726097de84b7525de74f8d5f6fbccc7L55-R81))
* Modified the `save` method in the `CookieStorage` class to encrypt the payload using AES-CBC before signing it with the JWT. Added comments explaining the choice of AES-CBC and its reliance on the JWT signature for tamper resistance. (`src/storage.ts`, [src/storage.tsL55-R81](diffhunk://#diff-10d5d48c419530b01c345d22a42140d1a726097de84b7525de74f8d5f6fbccc7L55-R81))

### Dependency Updates:
* Added `crypto-js` and its TypeScript types as dependencies in `package.json` to enable AES encryption and decryption. (`package.json`, [package.jsonR34-R36](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34-R36))

### Test Enhancements:
* Added a new test case to verify that the JWT payload is encrypted and cannot be parsed as plaintext JSON. (`tests/index.test.ts`, [tests/index.test.tsR78-R93](diffhunk://#diff-cece62ae24396a5d51e8f2a2cb3abba900652084488023f4de9669eaaf6f81e8R78-R93))
* Introduced a test case to validate the decryption and verification of JWTs, ensuring the correct restoration of session data. (`tests/index.test.ts`, [tests/index.test.tsR78-R93](diffhunk://#diff-cece62ae24396a5d51e8f2a2cb3abba900652084488023f4de9669eaaf6f81e8R78-R93))